### PR TITLE
Fixes build errors with gcc 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
       - <<: *osx
-        osx_image: xcode7.3
-        env: CONAN_APPLE_CLANG_VERSIONS=7.3
-      - <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1
       - <<: *osx

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,6 +42,12 @@ class LibpqxxRecipe(ConanFile):
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, self._source_subfolder)
 
+        # Fixes build errors with gcc 4.9: https://github.com/jtv/libpqxx/issues/161
+        tools.replace_in_file(
+            os.path.join(self._source_subfolder, "src", "encodings.cxx"),
+            "auto found_encoding_group{encoding_map.find(encoding_name)};",
+            "const auto found_encoding_group = encoding_map.find(encoding_name);")
+
     def _configure_autotools(self):
         if not self._autotools:
             args = [

--- a/conanfile.py
+++ b/conanfile.py
@@ -31,10 +31,18 @@ class LibpqxxRecipe(ConanFile):
             self.options.remove("fPIC")
 
     def configure(self):
+        compiler_version = Version(self.settings.compiler.version.value)
+
         if self.settings.os == "Windows" and \
            self.settings.compiler == "Visual Studio" and \
-           Version(self.settings.compiler.version.value) < "14":
+           compiler_version < "14":
             raise ConanInvalidConfiguration("Your MSVC version is too old, libpqxx requires C++14")
+
+        if self.settings.os == "Macos" and \
+           self.settings.compiler == "apple-clang" and \
+           compiler_version < "8.0":
+            raise ConanInvalidConfiguration(("libpqxx requires thread-local storage features,"
+                                             " could not be built by apple-clang < 8.0"))
 
     def source(self):
         sha256 = "00975df6d8e5a06060c232c7156ec63a2b0b8cbb097b6ac7833fa9e48f50d0ed"


### PR DESCRIPTION
Ref bincrafters/community#637, jtv/libpqxx#161

This patch is fixes build errors with gcc 4.9, ​​not necessary for libpqxx 6.3.1 and later versions.